### PR TITLE
Fix a relative link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This NPM Package allows Fig developers to quickly install and update tools that make building autocomplete easier. 
 
-To learn more about autocomplete, visit [github.com/withfig/autocomplete](github.com/withfig/autocomplete)
+To learn more about autocomplete, visit [github.com/withfig/autocomplete](https://github.com/withfig/autocomplete)
 
 Want to learn more? Join our [community discord](https://fig.io/community)
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
README fix

**What is the current behavior?**
There's a relative link to the `autocomplete` repo in the README, which causes a broken link on Openbase (https://openbase.com/js/fig) and GitHub (https://github.com/withfig/npm)

**What is the change made?**
The link is now absolute, and should work properly on Openbase and GitHub.